### PR TITLE
Fix: mcp adapter

### DIFF
--- a/mcp_config.py
+++ b/mcp_config.py
@@ -1,60 +1,7 @@
-import sys
-import os
-import tempfile
-import zipfile
-import pathlib
-import importlib.util
-
-
-def extract_roollm_dir() -> pathlib.Path:
-    """
-    Extracts the full hyphadevbot/roollm/ directory to a temp folder,
-    whether from a zipped .mbp or local dev. Returns the path to run_mcp_stdio.py
-    """
-    module_root = __name__.split(".")[0]
-    spec = importlib.util.find_spec(module_root)
-
-    if spec and spec.origin and spec.origin.endswith(".mbp"):
-        # running from a zipped plugin archive
-        with zipfile.ZipFile(spec.origin, "r") as zipf:
-            extracted_dir = pathlib.Path("/tmp/maubot_mcp/hyphadevbot")
-            for zipinfo in zipf.infolist():
-                if zipinfo.filename.startswith("hyphadevbot/roollm/"):
-                    out_path = extracted_dir / zipinfo.filename
-                    out_path.parent.mkdir(parents=True, exist_ok=True)
-                    zipf.extract(zipinfo, extracted_dir)
-                    print(f"✅ extracted: {out_path}")
-
-
-            script_path = extracted_dir / "hyphadevbot" / "roollm" / "run_mcp_stdio.py"
-            if not script_path.exists():
-                raise RuntimeError(f"🚨 run_mcp_stdio.py not found at: {script_path}")
-
-            sys.path.insert(0, str(extracted_dir))  # allow imports like minima_adapter
-            return script_path
-
-    else:
-        # fallback to local dev mode
-        here = pathlib.Path(__file__).parent
-        roollm_dir = here
-        extracted_dir = pathlib.Path(tempfile.mkdtemp())
-        extracted_roollm = extracted_dir / "hyphadevbot" / "roollm"
-        extracted_roollm.mkdir(parents=True, exist_ok=True)
-
-        for file in roollm_dir.glob("*.py"):
-            (extracted_roollm / file.name).write_text(file.read_text())
-
-        sys.path.insert(0, str(extracted_dir))
-        return extracted_roollm / "run_mcp_stdio.py"
-
-
-script_path = extract_roollm_dir()
-
 MCP_CONFIG = {
     "mcp_adapters": {
         "minima": {
-            "command": sys.executable,
-            "args": [str(script_path.resolve())],
+            "mode": "inline",
             "env": {
                 "MCP_ADAPTER": "minima_adapter.MinimaRestAdapter"
             }

--- a/minima_adapter.py
+++ b/minima_adapter.py
@@ -63,6 +63,7 @@ class MinimaRestAdapter:
             "query": {
                 "name": "query",
                 "description": "Find information in local files (PDF, CSV, DOCX, MD, TXT) and ALWAYS cite sources. You MUST include a citation for EVERY piece of information using the format [Source: handbook.hypha.coop/path/to/document]. Failing to cite sources is a critical error.",
+                "emoji": "🧠",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -73,6 +74,7 @@ class MinimaRestAdapter:
                     },
                     "required": ["text"]
                 }
+
             }
         }
         
@@ -382,6 +384,16 @@ class MinimaRestAdapter:
             "result": output,
             "source_paths": cleaned_sources
         }
+    
+    async def list_tools(self):
+        return [
+            {
+                "name": name,
+                "description": meta.get("description", ""),
+                "parameters": meta.get("parameters", {})
+            }
+            for name, meta in self.tools.items()
+        ]
 
     def verify_citations(self, response_content, source_paths):
         """

--- a/roollm.py
+++ b/roollm.py
@@ -28,16 +28,6 @@ def make_message(role, content):
         "content": content
     }
 
-def load_mcp_config():
-    try:
-        data = pkgutil.get_data(__package__, "mcp_config.json")
-        return json.loads(data.decode("utf-8"))
-    except Exception:
-        path = pathlib.Path(__file__).parent / "mcp_config.json"
-        return json.load(open(path, "r"))
-
-
-
 class RooLLM:
     def __init__(self, inference, config=None):
             self.inference = inference

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -18,6 +18,15 @@ class Tool:
                 "parameters": self.input_schema
             }
         }
+    
+    @classmethod
+    def from_dict(cls, d: dict, adapter_name: str = None):
+        return cls(
+            name=d["name"],
+            description=d.get("description", ""),
+            input_schema=d.get("parameters", {}), 
+            adapter_name=adapter_name
+        )
 
 class ToolRegistry:
     def __init__(self):


### PR DESCRIPTION
- removes .mbp zip unpacking hacks
- replaces subprocess-only architecture with hybrid inline / subprocess loader
- adds clean Tool.from_dict() handling
- aligns minima_adapter with the adapter interface contract
- simplifies deployment as a Maubot plugin by avoiding runtime extraction

