### PR TITLE
Add Minima metadata tools

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ import sys
 import socket
 import time
 from pathlib import Path
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Query
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from typing import Optional
@@ -169,6 +169,12 @@ class MinimaQueryRequest(BaseModel):
     query: str
     session_id: str
 
+class MinimaMetadataRequest(BaseModel):
+    path: Optional[str] = None
+    filename: Optional[str] = None
+    description: str = ""
+    tags: list[str] = []
+
 def get_minima_adapter():
     """Get the minima adapter from the bridge if available."""
     if not roo.bridge.initialized:
@@ -306,6 +312,57 @@ async def minima_status():
         "tools_count": len(tools),
         "tools": [tool.get("name") for tool in tools]
     }
+
+@app.get("/minima/metadata")
+async def minima_metadata(path: Optional[str] = Query(None), filename: Optional[str] = Query(None)):
+    adapter = get_minima_adapter()
+    if not adapter or not adapter.is_connected():
+        return {"status": "error", "message": "Not connected to Minima server"}
+    if not path and not filename:
+        return {"status": "error", "message": "path or filename is required"}
+    try:
+        result = await adapter.get_metadata(path=path, filename=filename)
+        if isinstance(result, dict) and result.get("error"):
+            return {"status": "error", "message": result["error"]}
+        return {"status": "ok", "metadata": result}
+    except Exception as e:
+        logger.error(f"Error fetching Minima metadata: {str(e)}")
+        return {"status": "error", "message": f"Error fetching metadata: {str(e)}"}
+
+@app.put("/minima/metadata")
+async def put_minima_metadata(request: MinimaMetadataRequest):
+    adapter = get_minima_adapter()
+    if not adapter or not adapter.is_connected():
+        return {"status": "error", "message": "Not connected to Minima server"}
+    if not request.path and not request.filename:
+        return {"status": "error", "message": "path or filename is required"}
+    try:
+        result = await adapter.put_metadata(
+            path=request.path,
+            filename=request.filename,
+            description=request.description,
+            tags=request.tags,
+        )
+        if isinstance(result, dict) and result.get("error"):
+            return {"status": "error", "message": result["error"]}
+        return {"status": "ok", "metadata": result}
+    except Exception as e:
+        logger.error(f"Error updating Minima metadata: {str(e)}")
+        return {"status": "error", "message": f"Error updating metadata: {str(e)}"}
+
+@app.get("/minima/files")
+async def minima_files():
+    adapter = get_minima_adapter()
+    if not adapter or not adapter.is_connected():
+        return {"status": "error", "message": "Not connected to Minima server"}
+    try:
+        result = await adapter.list_metadata()
+        if isinstance(result, dict) and result.get("error"):
+            return {"status": "error", "message": result["error"]}
+        return {"status": "ok", "files": result.get("files", []) if isinstance(result, dict) else []}
+    except Exception as e:
+        logger.error(f"Error listing Minima files: {str(e)}")
+        return {"status": "error", "message": f"Error listing files: {str(e)}"}
 
 @app.get("/minima/connect")
 async def connect_minima():

--- a/api/main.py
+++ b/api/main.py
@@ -316,6 +316,8 @@ async def minima_status():
 
 @app.get("/minima/metadata")
 async def minima_metadata(path: Optional[str] = Query(None), filename: Optional[str] = Query(None)):
+    if not config.get("USE_MINIMA_METADATA"):
+        return {"status": "error", "message": "Metadata feature is not enabled for this tenant"}
     adapter = get_minima_adapter()
     if not adapter or not adapter.is_connected():
         return {"status": "error", "message": "Not connected to Minima server"}
@@ -332,6 +334,8 @@ async def minima_metadata(path: Optional[str] = Query(None), filename: Optional[
 
 @app.put("/minima/metadata")
 async def put_minima_metadata(request: MinimaMetadataRequest):
+    if not config.get("USE_MINIMA_METADATA"):
+        return {"status": "error", "message": "Metadata feature is not enabled for this tenant"}
     adapter = get_minima_adapter()
     if not adapter or not adapter.is_connected():
         return {"status": "error", "message": "Not connected to Minima server"}
@@ -353,6 +357,8 @@ async def put_minima_metadata(request: MinimaMetadataRequest):
 
 @app.get("/minima/files")
 async def minima_files():
+    if not config.get("USE_MINIMA_METADATA"):
+        return {"status": "error", "message": "Metadata feature is not enabled for this tenant"}
     adapter = get_minima_adapter()
     if not adapter or not adapter.is_connected():
         return {"status": "error", "message": "Not connected to Minima server"}

--- a/api/main.py
+++ b/api/main.py
@@ -84,6 +84,7 @@ if isinstance(tenant_system_prompt, str):
     tenant_system_prompt = tenant_system_prompt.strip()
     if tenant_system_prompt:
         config["tenant_system_prompt"] = tenant_system_prompt
+config["USE_MINIMA_METADATA"] = branding_config.get("metadata", False)
 
 # Initialize LLM Client
 llm = LLMClient(

--- a/minima_adapter.py
+++ b/minima_adapter.py
@@ -51,10 +51,22 @@ class MinimaRestAdapter:
         self.connection_retry_interval = 10  # seconds
         
         # Define available tools
+        query_description = (
+            "Primary tool for searching the knowledge base. Use this first for questions about "
+            "documents, topics, file contents, or anything that may be answered from indexed files. "
+            "Results include content and source filename."
+        )
+        if self.metadata_enabled:
+            query_description = (
+                "Primary tool for searching the knowledge base. Use this first for questions about "
+                "documents, topics, file contents, or anything that may be answered from indexed files. "
+                "Results include content plus source metadata such as filename, description, and tags. "
+                "Preserves inline [Source: path] citations."
+            )
         self.tools = {
             "query": {
                 "name": "query",
-                "description": "Primary tool for searching the knowledge base. Use this first for questions about documents, topics, file contents, or anything that may be answered from indexed files. Results include content plus source metadata such as filename, description, and tags. Preserves inline [Source: path] citations.",
+                "description": query_description,
                 "emoji": "🗃️",
                 "parameters": {
                     "type": "object",
@@ -501,8 +513,16 @@ class MinimaRestAdapter:
 
             all_sources.append(source)
 
-            # Format the source citation
+            # Format the source citation, appending description/tags when metadata is enabled
             citation_text = f"[Source: {source}]"
+            if self.metadata_enabled:
+                chunk_metadata = chunk.get('metadata', {})
+                if isinstance(chunk_metadata, dict):
+                    desc = chunk_metadata.get('description', '').strip()
+                    tags = ", ".join(t for t in chunk_metadata.get('tags', []) if t)
+                    if desc or tags:
+                        parts = [p for p in [desc, f"tags: {tags}" if tags else ""] if p]
+                        citation_text += f" ({'; '.join(parts)})"
 
             # Add the content followed immediately by its citation
             formatted_output.append(f"{content} {citation_text}")

--- a/minima_adapter.py
+++ b/minima_adapter.py
@@ -37,9 +37,13 @@ class MinimaRestAdapter:
         # Check if Minima is enabled (from config or env var)
         config_minima = config.get("USE_MINIMA_MCP") if config else None
         env_minima = os.getenv("USE_MINIMA_MCP", "false").lower() == "true"
-        
+
         # If config value exists, convert it to bool, otherwise use env value
         self.using_minima = bool(config_minima) if config_minima is not None else env_minima
+
+        # Check if metadata tools are enabled (from config, set via branding.json)
+        config_metadata = config.get("USE_MINIMA_METADATA") if config else None
+        self.metadata_enabled = bool(config_metadata) if config_metadata is not None else False
         
         self.connected = False
         self.tools = {}
@@ -63,61 +67,65 @@ class MinimaRestAdapter:
                     "required": ["text"]
                 }
             },
-            "get_file_metadata": {
-                "name": "get_file_metadata",
-                "description": "Use only when the user explicitly asks for description/tags/metadata for a specific file, or after query has identified a relevant file and the user asks about that file's metadata. Use path when known, or filename when only the basename is known.",
-                "emoji": "🧾",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Optional file path, such as /documents/foo.pdf or a path under the Minima file root"
-                        },
-                        "filename": {
-                            "type": "string",
-                            "description": "Optional file basename, such as foo.pdf, when the full path is unknown"
-                        }
-                    }
-                }
-            },
-            "update_file_metadata": {
-                "name": "update_file_metadata",
-                "description": "Use only when the user explicitly asks to change a file's description or tags. Use path when known, or filename when only the basename is known.",
-                "emoji": "🖊️",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "type": "string",
-                            "description": "Optional file path, such as /documents/foo.pdf or a path under the Minima file root"
-                        },
-                        "filename": {
-                            "type": "string",
-                            "description": "Optional file basename, such as foo.pdf, when the full path is unknown"
-                        },
-                        "description": {
-                            "type": "string",
-                            "description": "Human-readable file description"
-                        },
-                        "tags": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "File tags"
-                        }
-                    }
-                }
-            },
-            "list_file_metadata": {
-                "name": "list_file_metadata",
-                "description": "Use only when the user asks to list or browse files or metadata records. Returns all files known to Minima with description, tags, filename, relative path, and path.",
-                "emoji": "🗂️",
-                "parameters": {
-                    "type": "object",
-                    "properties": {}
-                }
-            }
         }
+
+        if self.metadata_enabled:
+            self.tools.update({
+                "get_file_metadata": {
+                    "name": "get_file_metadata",
+                    "description": "Use only when the user explicitly asks for description/tags/metadata for a specific file, or after query has identified a relevant file and the user asks about that file's metadata. Use path when known, or filename when only the basename is known.",
+                    "emoji": "🧾",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "Optional file path, such as /documents/foo.pdf or a path under the Minima file root"
+                            },
+                            "filename": {
+                                "type": "string",
+                                "description": "Optional file basename, such as foo.pdf, when the full path is unknown"
+                            }
+                        }
+                    }
+                },
+                "update_file_metadata": {
+                    "name": "update_file_metadata",
+                    "description": "Use only when the user explicitly asks to change a file's description or tags. Use path when known, or filename when only the basename is known.",
+                    "emoji": "🖊️",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "Optional file path, such as /documents/foo.pdf or a path under the Minima file root"
+                            },
+                            "filename": {
+                                "type": "string",
+                                "description": "Optional file basename, such as foo.pdf, when the full path is unknown"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Human-readable file description"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "File tags"
+                            }
+                        }
+                    }
+                },
+                "list_file_metadata": {
+                    "name": "list_file_metadata",
+                    "description": "Use only when the user asks to list or browse files or metadata records. Returns all files known to Minima with description, tags, filename, relative path, and path.",
+                    "emoji": "🗂️",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                },
+            })
         
     async def connect(self, force=False):
         """

--- a/minima_adapter.py
+++ b/minima_adapter.py
@@ -50,8 +50,8 @@ class MinimaRestAdapter:
         self.tools = {
             "query": {
                 "name": "query",
-                "description": "Search the knowledge base for relevant documents. Returns passages with inline citations: 'content [Source: path]'. When presenting information to users, preserve these [Source: ...] citations exactly as they appear in the results.",
-                "emoji": "🧠",
+                "description": "Primary tool for searching the knowledge base. Use this first for questions about documents, topics, file contents, or anything that may be answered from indexed files. Results include content plus source metadata such as filename, description, and tags. Preserves inline [Source: path] citations.",
+                "emoji": "🗃️",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -61,6 +61,60 @@ class MinimaRestAdapter:
                         }
                     },
                     "required": ["text"]
+                }
+            },
+            "get_file_metadata": {
+                "name": "get_file_metadata",
+                "description": "Use only when the user explicitly asks for description/tags/metadata for a specific file, or after query has identified a relevant file and the user asks about that file's metadata. Use path when known, or filename when only the basename is known.",
+                "emoji": "🧾",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Optional file path, such as /documents/foo.pdf or a path under the Minima file root"
+                        },
+                        "filename": {
+                            "type": "string",
+                            "description": "Optional file basename, such as foo.pdf, when the full path is unknown"
+                        }
+                    }
+                }
+            },
+            "update_file_metadata": {
+                "name": "update_file_metadata",
+                "description": "Use only when the user explicitly asks to change a file's description or tags. Use path when known, or filename when only the basename is known.",
+                "emoji": "🖊️",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Optional file path, such as /documents/foo.pdf or a path under the Minima file root"
+                        },
+                        "filename": {
+                            "type": "string",
+                            "description": "Optional file basename, such as foo.pdf, when the full path is unknown"
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Human-readable file description"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "File tags"
+                        }
+                    }
+                }
+            },
+            "list_file_metadata": {
+                "name": "list_file_metadata",
+                "description": "Use only when the user asks to list or browse files or metadata records. Returns all files known to Minima with description, tags, filename, relative path, and path.",
+                "emoji": "🗂️",
+                "parameters": {
+                    "type": "object",
+                    "properties": {}
                 }
             }
         }
@@ -232,7 +286,31 @@ class MinimaRestAdapter:
         
         if name not in self.tools:
             return {"error": f"Tool {name} not found"}
-            
+
+        if name == "get_file_metadata":
+            arguments = arguments if isinstance(arguments, dict) else {}
+            path = arguments.get("path")
+            filename = arguments.get("filename")
+            if not path and not filename:
+                return {"error": "path or filename is required"}
+            return await self.get_metadata(path=path, filename=filename)
+
+        if name == "update_file_metadata":
+            arguments = arguments if isinstance(arguments, dict) else {}
+            path = arguments.get("path")
+            filename = arguments.get("filename")
+            if not path and not filename:
+                return {"error": "path or filename is required"}
+            return await self.put_metadata(
+                path=path,
+                filename=filename,
+                description=arguments.get("description", ""),
+                tags=arguments.get("tags", []),
+            )
+
+        if name == "list_file_metadata":
+            return await self.list_metadata()
+
         if name != "query":
             return {"error": "Unsupported tool"}
             
@@ -321,6 +399,63 @@ class MinimaRestAdapter:
                 return {"error": f"Connection error: {str(e)}"}
                 
         return {"error": "Query request failed after multiple attempts"}
+
+    async def get_metadata(self, path=None, filename=None):
+        if not self.connected and not await self.connect():
+            return {"error": "Could not connect to Minima indexer"}
+
+        endpoint = "metadata/by-filename" if filename and not path else "metadata"
+        params = {"filename": filename} if endpoint.endswith("by-filename") else {"path": path}
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.server_url}/{endpoint}",
+                params=params,
+                timeout=30,
+            ) as response:
+                try:
+                    payload = await response.json()
+                except json.JSONDecodeError:
+                    payload = {"error": await response.text()}
+                if response.status != 200:
+                    return {"error": payload.get("detail") or payload.get("error") or "Metadata request failed"}
+                return payload
+
+    async def put_metadata(self, path=None, description="", tags=None, filename=None):
+        if not self.connected and not await self.connect():
+            return {"error": "Could not connect to Minima indexer"}
+
+        payload = {"description": description, "tags": tags or []}
+        if path:
+            payload["path"] = path
+        if filename:
+            payload["filename"] = filename
+        async with aiohttp.ClientSession() as session:
+            async with session.put(
+                f"{self.server_url}/metadata",
+                json=payload,
+                timeout=30,
+            ) as response:
+                try:
+                    payload = await response.json()
+                except json.JSONDecodeError:
+                    payload = {"error": await response.text()}
+                if response.status != 200:
+                    return {"error": payload.get("detail") or payload.get("error") or "Metadata update failed"}
+                return payload
+
+    async def list_metadata(self):
+        if not self.connected and not await self.connect():
+            return {"error": "Could not connect to Minima indexer"}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{self.server_url}/metadata/list", timeout=30) as response:
+                try:
+                    payload = await response.json()
+                except json.JSONDecodeError:
+                    payload = {"error": await response.text()}
+                if response.status != 200:
+                    return {"error": payload.get("detail") or payload.get("error") or "Metadata list request failed"}
+                return payload
 
     def _format_result_with_chunk_citations(self, chunks):
         """

--- a/tests/test_minima_metadata.py
+++ b/tests/test_minima_metadata.py
@@ -1,0 +1,145 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from minima_adapter import MinimaRestAdapter
+
+
+def make_adapter(metadata_enabled: bool) -> MinimaRestAdapter:
+    config = {
+        "USE_MINIMA_MCP": True,
+        "USE_MINIMA_METADATA": metadata_enabled,
+        "MINIMA_MCP_SERVER_URL": "http://localhost:8001",
+    }
+    return MinimaRestAdapter(config=config)
+
+
+class TestMetadataToolGating(unittest.TestCase):
+    def test_metadata_tools_absent_when_disabled(self):
+        adapter = make_adapter(metadata_enabled=False)
+        self.assertNotIn("get_file_metadata", adapter.tools)
+        self.assertNotIn("update_file_metadata", adapter.tools)
+        self.assertNotIn("list_file_metadata", adapter.tools)
+
+    def test_metadata_tools_present_when_enabled(self):
+        adapter = make_adapter(metadata_enabled=True)
+        self.assertIn("get_file_metadata", adapter.tools)
+        self.assertIn("update_file_metadata", adapter.tools)
+        self.assertIn("list_file_metadata", adapter.tools)
+
+    def test_query_tool_always_present(self):
+        self.assertIn("query", make_adapter(metadata_enabled=False).tools)
+        self.assertIn("query", make_adapter(metadata_enabled=True).tools)
+
+    def test_query_description_omits_metadata_when_disabled(self):
+        desc = make_adapter(metadata_enabled=False).tools["query"]["description"]
+        self.assertNotIn("description", desc)
+        self.assertNotIn("tags", desc)
+
+    def test_query_description_mentions_metadata_when_enabled(self):
+        desc = make_adapter(metadata_enabled=True).tools["query"]["description"]
+        self.assertIn("description", desc)
+        self.assertIn("tags", desc)
+
+    def test_metadata_disabled_flag_default_without_config_key(self):
+        adapter = MinimaRestAdapter(config={"USE_MINIMA_MCP": True})
+        self.assertFalse(adapter.metadata_enabled)
+
+
+class TestChunkCitationFormatting(unittest.TestCase):
+    def _format(self, adapter, chunks):
+        return adapter._format_result_with_chunk_citations(chunks)
+
+    def test_plain_citation_when_metadata_disabled(self):
+        adapter = make_adapter(metadata_enabled=False)
+        chunks = [{"content": "hello", "source": "file://doc.pdf", "metadata": {"description": "desc", "tags": ["a"]}}]
+        result = self._format(adapter, chunks)
+        self.assertIn("[Source: file://doc.pdf]", result["result"])
+        self.assertNotIn("desc", result["result"])
+        self.assertNotIn("tags:", result["result"])
+
+    def test_citation_includes_description_when_enabled(self):
+        adapter = make_adapter(metadata_enabled=True)
+        chunks = [{"content": "hello", "source": "file://doc.pdf", "metadata": {"description": "my description", "tags": []}}]
+        result = self._format(adapter, chunks)
+        self.assertIn("my description", result["result"])
+        self.assertIn("[Source: file://doc.pdf]", result["result"])
+
+    def test_citation_includes_tags_when_enabled(self):
+        adapter = make_adapter(metadata_enabled=True)
+        chunks = [{"content": "hello", "source": "file://doc.pdf", "metadata": {"description": "", "tags": ["foo", "bar"]}}]
+        result = self._format(adapter, chunks)
+        self.assertIn("tags: foo, bar", result["result"])
+
+    def test_citation_includes_both_desc_and_tags_when_enabled(self):
+        adapter = make_adapter(metadata_enabled=True)
+        chunks = [{"content": "hello", "source": "file://doc.pdf", "metadata": {"description": "my desc", "tags": ["t1"]}}]
+        result = self._format(adapter, chunks)
+        self.assertIn("my desc", result["result"])
+        self.assertIn("tags: t1", result["result"])
+
+    def test_citation_plain_when_enabled_but_no_metadata_field(self):
+        adapter = make_adapter(metadata_enabled=True)
+        chunks = [{"content": "hello", "source": "file://doc.pdf"}]
+        result = self._format(adapter, chunks)
+        self.assertIn("[Source: file://doc.pdf]", result["result"])
+        self.assertNotIn("tags:", result["result"])
+
+    def test_citation_plain_when_enabled_but_empty_metadata(self):
+        adapter = make_adapter(metadata_enabled=True)
+        chunks = [{"content": "hello", "source": "file://doc.pdf", "metadata": {"description": "", "tags": []}}]
+        result = self._format(adapter, chunks)
+        self.assertEqual(result["result"].strip(), "hello [Source: file://doc.pdf]")
+
+    def test_invalid_chunk_skipped(self):
+        adapter = make_adapter(metadata_enabled=False)
+        chunks = [{"content": "good", "source": "file://a.pdf"}, {"bad": "chunk"}]
+        result = self._format(adapter, chunks)
+        self.assertIn("good", result["result"])
+
+    def test_empty_chunks_returns_warning(self):
+        adapter = make_adapter(metadata_enabled=False)
+        result = self._format(adapter, [])
+        self.assertIn("WARNING", result["result"])
+
+
+class TestMetadataAPIEndpointGating(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        import api.main as main_module
+        from fastapi.testclient import TestClient
+
+        self._orig_config = dict(main_module.config)
+
+        main_module.config["USE_MINIMA_METADATA"] = False
+        self.client = TestClient(main_module.app, raise_server_exceptions=False)
+        self.main = main_module
+
+    async def asyncTearDown(self):
+        import api.main as main_module
+        main_module.config.clear()
+        main_module.config.update(self._orig_config)
+
+    def test_get_metadata_blocked_when_disabled(self):
+        response = self.client.get("/minima/metadata?path=/docs/file.pdf")
+        data = response.json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("not enabled", data["message"])
+
+    def test_put_metadata_blocked_when_disabled(self):
+        response = self.client.put("/minima/metadata", json={"path": "/docs/file.pdf", "description": "x", "tags": []})
+        data = response.json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("not enabled", data["message"])
+
+    def test_get_files_blocked_when_disabled(self):
+        response = self.client.get("/minima/files")
+        data = response.json()
+        self.assertEqual(data["status"], "error")
+        self.assertIn("not enabled", data["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tool_constants.json
+++ b/tool_constants.json
@@ -70,7 +70,7 @@
     },
     "📖": {
       "tool": "search_handbook",
-      "description": "Search Hypha's handbook"
+      "description": "Search the knowledge base"
     },
     "📅": {
       "tool": "get_upcoming_holiday",
@@ -92,9 +92,21 @@
       "tool": "web_search",
       "description": "Search the internet for current information using Claude with web search"
     },
-    "🧠": {
+    "🗃️": {
       "tool": "query",
-      "description": "Search the knowledge base for relevant documents with RAG via minima MCP"
+      "description": "Search files in the knowledge base"
+    },
+    "🧾": {
+      "tool": "get_file_metadata",
+      "description": "Get description and tags for a file in Minima"
+    },
+    "🖊️": {
+      "tool": "update_file_metadata",
+      "description": "Update description and tags for a file in Minima"
+    },
+    "🗂️": {
+      "tool": "list_file_metadata",
+      "description": "List files known to Minima with their description, tags, filename, relative path, and path"
     },
     "🧭": {
       "tool": "consensus_analyzer",


### PR DESCRIPTION
Adds \`get_file_metadata\`, \`update_file_metadata\`, and \`list_file_metadata\` as agent tools backed by new Minima REST endpoints (\`GET /minima/metadata\`, \`PUT /minima/metadata\`, \`GET /minima/files\`).

## Feature Flag

All metadata functionality is gated by a \`metadata: true/false\` flag in the tenant's \`branding.json\`. Disabled by default.

**When \`metadata: false\` (default):**
- The three metadata agent tools are not registered
- \`GET /minima/metadata\`, \`PUT /minima/metadata\`, \`GET /minima/files\` return an explicit error
- The \`query\` tool description only mentions filenames (no description/tags)
- Query results include only \`[Source: path]\` citations — metadata fields are stripped

**When \`metadata: true\`:**
- All three agent tools are registered and available to the LLM
- API endpoints are open
- The \`query\` tool description advertises description and tag support
- Query results append description and tags to each \`[Source: path]\` citation when present

## How the flag flows in

\`api/main.py\` reads \`branding.json\` at startup and sets \`config["USE_MINIMA_METADATA"]\`. \`MinimaRestAdapter\` reads it via \`config.get("USE_MINIMA_METADATA")\` and sets \`self.metadata_enabled\`.

## Dependencies

- Depends on **minima PR #9** for the \`/metadata\` and \`/metadata/list\` backend endpoints
- Tenant opt-in via \`metadata: true\` in \`branding.json\` (see roo-multitenant, where vincent tenant is the first opt-in)